### PR TITLE
Copy pipeasio dll without preserving mode in pipeasio-register

### DIFF
--- a/pipeasio-register
+++ b/pipeasio-register
@@ -46,8 +46,8 @@ fi
 
 # Stage the PE fake into the prefix's system32 so COM registration's
 # LoadLibrary resolves pipeasio64.dll by name.
-cp -v "${prefix}/x86_64-windows/pipeasio64.dll" \
-      "${WINEPREFIX}/drive_c/windows/system32/" || exit $?
+cp -v --no-preserve mode "${prefix}/x86_64-windows/pipeasio64.dll" \
+                         "${WINEPREFIX}/drive_c/windows/system32/" || exit $?
 
 # WINEDLLPATH lets Wine (host wine for this registration; Proton's wine at
 # runtime — both need it for user-local installs) find the ELF .so half


### PR DESCRIPTION
This is somewhat NixOS specific, but shouldn't cause any issues in general/on other distros.

The problem occurs if the source `pipeasio64.dll` has read-only permissions set and `pipeasio-register` gets called multiple times:
```
cp: cannot create regular file '<...>/.wine/drive_c/windows/system32/pipeasio64.dll': Permission denied
```

Adding `--no-preserve mode` to the `cp` command makes it so that the `pipeasio64.dll` in the wine prefix inherits its permissions from the parent directory it gets copied too (`.../drive_c/windows/system32`), instead of the source `pipeasio64.dll`.