### PR TITLE
fix: pipeasio-register prefers wine64 (Fixes #9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `pipeasio-register` failed with `regsvr32 failed (status 3)` on runner
+  builds where `bin/wine` is the 32-bit loader (kron4ek, proton
+  derivatives — the usual Bottles runners): the 32-bit `regsvr32` cannot
+  `LoadLibrary` the 64-bit `pipeasio64.dll`
+  ([#9](https://github.com/M0n7y5/pipeasio/issues/9)).  The script now
+  prefers `wine64` when it exists and falls back to `wine` otherwise.
+
 ## [1.2.3] - 2026-07-21
 
 ### Added

--- a/pipeasio-register
+++ b/pipeasio-register
@@ -3,8 +3,15 @@ me=pipeasio-register
 
 WINEPREFIX=${WINEPREFIX:=~/.wine}
 
+# 64-bit registration must run in a 64-bit process: on runner builds
+# (kron4ek, proton derivatives) bin/wine is the 32-bit loader, whose
+# regsvr32 cannot LoadLibrary the 64-bit pipeasio64.dll and fails with
+# status 3 (issue #9).  Prefer wine64 when it exists; plain wine is the
+# fallback (upstream builds where both are the same loader anyway).
+WINE="$(command -v wine64 || command -v wine)"
+
 if [ ! -d "${WINEPREFIX}" ]; then
-    wineboot -u || exit $?
+    wineboot -u || exit $?  # prefix bootstrap is arch-agnostic
 fi
 
 # Candidate install roots, in preference order.
@@ -44,7 +51,7 @@ cp -v --no-preserve mode "${prefix}/x86_64-windows/pipeasio64.dll" \
 
 # Let Wine find the ELF half next to the PE half.
 export WINEDLLPATH="${prefix}${WINEDLLPATH:+:${WINEDLLPATH}}"
-wine regsvr32 pipeasio64.dll
+"${WINE}" regsvr32 pipeasio64.dll
 code=$?
 
 # Optional 32-bit WoW64 registration.
@@ -55,19 +62,19 @@ if [ ${code} -eq 0 ] \
     mkdir -p "${WINEPREFIX}/drive_c/windows/syswow64" || exit $?
     cp -v --no-preserve mode "${prefix}/i386-windows/pipeasio32.dll" \
                              "${WINEPREFIX}/drive_c/windows/syswow64/" || exit $?
-    wine reg add \
+    "${WINE}" reg add \
         'HKCR\CLSID\{2D3CA9E2-1193-4C5D-B5FD-38798F3DC074}\InprocServer32' \
         /ve /t REG_SZ /d 'pipeasio32.dll' /f /reg:32 || exit $?
-    wine reg add \
+    "${WINE}" reg add \
         'HKCR\CLSID\{2D3CA9E2-1193-4C5D-B5FD-38798F3DC074}\InprocServer32' \
         /v ThreadingModel /t REG_SZ /d Apartment /f /reg:32 || exit $?
-    wine reg add \
+    "${WINE}" reg add \
         'HKCU\Software\Wine\DllOverrides' \
         /v pipeasio32 /t REG_SZ /d builtin /f /reg:32 || exit $?
-    wine reg add \
+    "${WINE}" reg add \
         'HKLM\Software\ASIO\PipeASIO' \
         /v CLSID /t REG_SZ /d '{2D3CA9E2-1193-4C5D-B5FD-38798F3DC074}' /f /reg:32 || exit $?
-    wine reg add \
+    "${WINE}" reg add \
         'HKLM\Software\ASIO\PipeASIO' \
         /v Description /t REG_SZ /d 'PipeASIO Driver' /f /reg:32 || exit $?
     >&2 echo "[${me}] 32-bit WoW64 front end registered"


### PR DESCRIPTION
Fixes #9.

On runner builds where `bin/wine` is the **32-bit loader** (kron4ek, proton derivatives — the usual Bottles runners), `wine regsvr32 pipeasio64.dll` runs a 32-bit `regsvr32`, which cannot `LoadLibrary` the 64-bit `pipeasio64.dll` and exits with status 3 (`regsvr32: Unable to load DLL`). This is what #9 hit on Bottles/AUR — not a distro issue.

`pipeasio-register` now prefers `wine64` when it exists and falls back to `wine` otherwise (upstream builds ship both names for the same loader, so behavior there is unchanged).

Verified on `kron4ek-wine-proton-10.0-4-amd64` with a fresh prefix: registration succeeds and `HKLM\Software\ASIO\PipeASIO` lands in the 64-bit registry view.

Side note for anyone verifying registration by hand: reading the key from a 32-bit process (bare `wine reg query`) follows the Wow6432Node redirect and does **not** see the 64-bit registration — use `wine reg query ... /reg:64`.
